### PR TITLE
Enable sbt-sonatype in plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")


### PR DESCRIPTION
`sbt-sonatype` plugin was not explicitly enabled, so SBT was not able to parse `build.sbt`